### PR TITLE
sewing_test errors on Windows

### DIFF
--- a/include/sewing.h
+++ b/include/sewing.h
@@ -41,7 +41,7 @@ typedef struct Sew_Thread
 {
     HANDLE handle;
     DWORD  id;
-};
+} Sew_Thread;
 
 #else
 

--- a/test/sewing_test.c
+++ b/test/sewing_test.c
@@ -158,17 +158,12 @@ void Sew_Test_Set_hwloc_thread_affinity
                             !hwloc_set_thread_cpubind
                             (
                                 t
-                                , threads[threads_left - 1]
+                                , threads[threads_left - 1].handle
                                 , cpu
                                 , HWLOC_CPUBIND_THREAD
                             )
                             )
                     {
-                        char *str;
-                        hwloc_bitmap_asprintf(&str, cpu);
-
-                        free(str);
-
                         threads_left--;
 
                         if (!threads_left)
@@ -177,7 +172,7 @@ void Sew_Test_Set_hwloc_thread_affinity
                         }
                     }
 
-                    free(cpu);
+					hwloc_bitmap_free(cpu);
                 }
             }
         }

--- a/test/sewing_test.c
+++ b/test/sewing_test.c
@@ -172,7 +172,7 @@ void Sew_Test_Set_hwloc_thread_affinity
                         }
                     }
 
-					hwloc_bitmap_free(cpu);
+                    hwloc_bitmap_free(cpu);
                 }
             }
         }

--- a/test/sewing_test.c
+++ b/test/sewing_test.c
@@ -158,7 +158,13 @@ void Sew_Test_Set_hwloc_thread_affinity
                             !hwloc_set_thread_cpubind
                             (
                                 t
-                                , threads[threads_left - 1].handle
+#if __linux__
+                                , threads[threads_left - 1]
+#elif defined(_WIN32)
+								, threads[threads_left - 1].handle
+#else
+#error Platform not supported, sorry.
+#endif
                                 , cpu
                                 , HWLOC_CPUBIND_THREAD
                             )


### PR DESCRIPTION
There were some crashes here on windows:
- Not sure why, but freeing the string allocated by hwloc_bitmap_asprintf crashed. The string wasn't being used anyway, so I removed those lines.
- free(cpu) was crashing, so I replaced that with the hwloc function that seems to be correct.

There was also a compile error on line 161.
